### PR TITLE
Add `FieldsMustMatch` rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # POJO testing library
 
-![GitHub release](https://img.shields.io/github/v/release/fabasoad/pojo?include_prereleases) ![Unit Tests](https://github.com/fabasoad/pojo/workflows/Unit%20Tests/badge.svg) ![Security Tests](https://github.com/fabasoad/pojo/workflows/Security%20Tests/badge.svg) [![pre-commit.ci status](https://results.pre-commit.ci/badge/github/fabasoad/pojo/main.svg)](https://results.pre-commit.ci/latest/github/fabasoad/pojo/main) [![BCH compliance](https://bettercodehub.com/edge/badge/fabasoad/pojo?branch=main)](https://bettercodehub.com/) [![Known Vulnerabilities](https://snyk.io/test/github/fabasoad/pojo/badge.svg?targetFile=package.json)](https://snyk.io/test/github/fabasoad/pojo?targetFile=package.json)
+![GitHub release](https://img.shields.io/github/v/release/fabasoad/pojo?include_prereleases) ![Unit Tests](https://github.com/fabasoad/pojo/workflows/Unit%20Tests/badge.svg) ![Security Tests](https://github.com/fabasoad/pojo/workflows/Security%20Tests/badge.svg) [![pre-commit.ci status](https://results.pre-commit.ci/badge/github/fabasoad/pojo/main.svg)](https://results.pre-commit.ci/latest/github/fabasoad/pojo/main) [![BCH compliance](https://bettercodehub.com/edge/badge/fabasoad/pojo?branch=main)](https://bettercodehub.com/) [![Known Vulnerabilities](https://snyk.io/test/github/fabasoad/pojo/badge.svg)](https://snyk.io/test/github/fabasoad/pojo)
 
 ## Import
 
@@ -13,7 +13,7 @@
 <dependency>
   <groupId>io.fabasoad</groupId>
   <artifactId>pojo</artifactId>
-  <version>0.1.0</version>
+  <version>0.2.0</version>
 </dependency>
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group 'io.fabasoad'
-version '0.1.0'
+version '0.2.0'
 
 repositories {
     mavenCentral()

--- a/src/main/groovy/io/fabasoad/pojo/validator/rules/fields/FieldsMustMatchRule.groovy
+++ b/src/main/groovy/io/fabasoad/pojo/validator/rules/fields/FieldsMustMatchRule.groovy
@@ -1,0 +1,35 @@
+package io.fabasoad.pojo.validator.rules.fields
+
+import java.lang.reflect.Field
+import java.util.regex.Pattern
+
+/**
+ * This rule checks that fields' names must match regex.
+ *
+ * Positive examples in case regex is "$(_.+)^":
+ * <code>
+ *  public class Pojo1 {
+ *    private final byte _code;
+ *    private int _count;
+ *  }
+ *
+ *  public record Pojo2(String name) {}
+ * </code>
+ *
+ * Negative examples in case regex is "$(_.+)^":
+ * <code>
+ *   public class Pojo {
+ *     String name;
+ *     public byte Code;
+ *   }
+ * </code>
+ */
+class FieldsMustMatchRule extends CustomFieldRule {
+
+    FieldsMustMatchRule(regex) {
+        super(
+                { Field f -> (f.name =~ Pattern.compile(regex)).find() },
+                { "Field '" + it.name + "' doesn't match '" + regex }
+        )
+    }
+}

--- a/src/main/groovy/io/fabasoad/pojo/validator/rules/fields/FieldsMustMatchRule.groovy
+++ b/src/main/groovy/io/fabasoad/pojo/validator/rules/fields/FieldsMustMatchRule.groovy
@@ -6,7 +6,7 @@ import java.util.regex.Pattern
 /**
  * This rule checks that fields' names must match regex.
  *
- * Positive examples in case regex is "$(_.+)^":
+ * Positive examples in case regex is "_.+":
  * <code>
  *  public class Pojo1 {
  *    private final byte _code;
@@ -16,7 +16,7 @@ import java.util.regex.Pattern
  *  public record Pojo2(String name) {}
  * </code>
  *
- * Negative examples in case regex is "$(_.+)^":
+ * Negative examples in case regex is "_.+":
  * <code>
  *   public class Pojo {
  *     String name;

--- a/src/test/groovy/io/fabasoad/pojo/validator/testers/FieldsTesterSpec.groovy
+++ b/src/test/groovy/io/fabasoad/pojo/validator/testers/FieldsTesterSpec.groovy
@@ -5,6 +5,7 @@ import io.fabasoad.pojo.validator.exceptions.ValidationException
 import io.fabasoad.pojo.validator.rules.fields.CustomFieldRule
 import io.fabasoad.pojo.validator.rules.fields.FieldsMustBeFinalRule
 import io.fabasoad.pojo.validator.rules.fields.FieldsMustBePrivateRule
+import io.fabasoad.pojo.validator.rules.fields.FieldsMustMatchRule
 import io.fabasoad.pojo.validator.rules.fields.FieldsMustNotBePublicRule
 import spock.lang.Specification
 
@@ -26,11 +27,12 @@ class FieldsTesterSpec extends Specification {
     validator.validate({ expected.contains(it.simpleName) })
 
     where:
-    rule                            | expected
-    new FieldsMustBeFinalRule()     | ["A"]
-    new FieldsMustBePrivateRule()   | ["A", "B"]
-    new FieldsMustNotBePublicRule() | ["A", "B", "D", "E"]
-    customFieldRule                 | ["E"]
+    rule                              | expected
+    new FieldsMustBeFinalRule()       | ["A"]
+    new FieldsMustBePrivateRule()     | ["A", "B"]
+    new FieldsMustNotBePublicRule()   | ["A", "B", "D", "E"]
+    new FieldsMustMatchRule(".*na.*") | ["A", "B", "C"]
+    customFieldRule                   | ["E"]
   }
 
   def "Fields must follow the rule :: negative"() {
@@ -41,16 +43,26 @@ class FieldsTesterSpec extends Specification {
     builder
         .with(new FieldsTester(rule))
         .build()
-        .validate({ expected.contains(it.simpleName) })
+        .validate({ expected == it.simpleName })
 
     then:
     thrown(ValidationException)
 
     where:
-    rule                            | expected
-    new FieldsMustBeFinalRule()     | ["B", "C", "D", "E"]
-    new FieldsMustBePrivateRule()   | ["C", "D", "E"]
-    new FieldsMustNotBePublicRule() | ["C"]
-    customFieldRule                 | ["A", "B", "C", "D"]
+    rule                              | expected
+    new FieldsMustBeFinalRule()       | "B"
+    new FieldsMustBeFinalRule()       | "C"
+    new FieldsMustBeFinalRule()       | "D"
+    new FieldsMustBeFinalRule()       | "E"
+    new FieldsMustBePrivateRule()     | "C"
+    new FieldsMustBePrivateRule()     | "D"
+    new FieldsMustBePrivateRule()     | "E"
+    new FieldsMustNotBePublicRule()   | "C"
+    new FieldsMustMatchRule(".*na.*") | "D"
+    new FieldsMustMatchRule(".*co.*") | "B"
+    customFieldRule                   | "A"
+    customFieldRule                   | "B"
+    customFieldRule                   | "C"
+    customFieldRule                   | "D"
   }
 }


### PR DESCRIPTION
## FieldsMustMatch

This rule helps to test fields' names using regex

### Examples

Positive examples in case regex is `_.+`:

```java
public class Pojo1 {
  private final byte _code;
  private int _count;
}

public record Pojo2(String name) {}
```

Negative examples in case regex is `_.+`:

```java
public class Pojo {
  String name;
  public byte Code;
}
```

### How to use

#### Java

```java
public class PojoTest {
  // The package to test
  private static final String PACKAGE_NAME = "io.fabasoad.pojo";

  @Test
  public void testPojoStructureAndBehavior() {
    final PojoValidator validator = PojoValidatorBuilder.create(PACKAGE_NAME)
        .with(new FieldsTester(
            new FieldsMustMatchRule("_.+")))
        .build();

    validator.validate();
  }
}
```

#### Groovy

```groovy
class PojoSpec extends Specification {
  // The package to test
  def PACKAGE_NAME = "io.fabasoad.pojo";

  def "Getters and fields must follow the rules"() {
    given:
    def builder = PojoValidatorBuilder.create(PACKAGE_NAME)

    when:
    def validator = builder
        .with(new FieldsTester(
            new FieldsMustMatchRule("_.+")))
        .build()

    then:
    validator.validate()
  }
}
```